### PR TITLE
Minor tidy-ups

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -74,20 +74,20 @@ msgstr ""
 
 msgctxt "#32208"
 msgid "Enter postcode, suburb or area."
-msgstr "
+msgstr ""
 
 msgctxt "#32209"
 msgid "Radar backgrounds not showing?  Try forcing a refresh"
-msgstr "
+msgstr ""
 
 msgctxt "#32210"
 msgid "Refresh all radar backgrounds on next weather fetch?"
-msgstr "
+msgstr ""
 
 msgctxt "#32211"
 msgid "Closest Radar "
-msgstr "
+msgstr ""
 
 msgctxt "#32212"
 msgid "If entered, these radar codes overrule the closest found."
-msgstr "
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -357,7 +357,7 @@
 					</group>
 					<setting id="Radar1" type="string" label="32155" help="">
 						<level>0</level>
-						<default></default>
+						<default/>
 						<constraints>
 							<allowempty>true</allowempty>
 						</constraints>
@@ -406,7 +406,7 @@
 							<heading>32157</heading>
 						</control>
 					</setting>
-			</group>
+            </group>
 			<group id="2" label="32209">
 				<setting id="PurgeRadarBackgroundsOnNextRefresh" type="boolean" label="32210" help="">
 					<level>0</level>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected English (UK) translation entries to valid syntax, ensuring radar-related prompts and labels display correctly (e.g., postcode entry, refresh/background messages, closest radar notes).
- Chores
  - Cleaned up settings XML formatting, replacing an empty default element with a self-closing tag and normalizing whitespace. No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->