### PR TITLE
Fix (and make more robust) ABC weather video scraping

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="OzWeather" version="2.1.8" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="OzWeather" version="2.1.9" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -23,8 +23,8 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>v2.1.8 
-- Add RadarRange label
+		<news>v2.1.9
+- Fix ABC weather video scraping due to upstream changes
     	</news>
 	</extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.9
+- Fix ABC weather video scraping due to upstream changes
+
 v2.1.8 
 - Add RadarRange label
 

--- a/resources/lib/abc/abc_video.py
+++ b/resources/lib/abc/abc_video.py
@@ -1,4 +1,5 @@
 import requests
+import re
 import sys
 import xbmc
 import xbmcgui
@@ -35,7 +36,6 @@ def scrape_and_play_abc_weather_video():
     pass
 
 
-# See bottom of this file for notes on matching the video links (& Store.py for the regex)
 def get_abc_weather_video_link():
     try:
         r = requests.get(Store.ABC_URL, timeout=15)
@@ -45,16 +45,47 @@ def get_abc_weather_video_link():
             error_msg = "ABC __NEXT_DATA__ script not found on page, couldn't extract ABC weather video link"
             Logger.error(error_msg)
             raise ValueError(error_msg)
+
         json_object = json.loads(json_string.string)
+
         # Logger.debug(json_object)
         # Put the json blob into: https://jsonhero.io/j/JU0I9LB4AlLU
         # Gives a path to the needed video as:
         # $.props.pageProps.channelpage.components.0.component.props.list.3.player.config.sources.1.file
         # Rather than grab the URL directly (as place in array might change), grab all the available URLs and get the best quality from it
         # See: https://github.com/bossanova808/weather.ozweather/commit/e6158d704fc160808bf66220da711805860d85c7
-        data = json_object['props']['pageProps']['channelpage']['components'][0]['component']['props']['list'][3]
-        urls = [x for x in data['player']['config']['sources'] if x['type'] == 'video/mp4']
-        return sorted(urls, key=lambda x: x['bitrate'], reverse=True)[0]['file']
+
+        items = json_object['props']['pageProps']['channelpage']['components'][0]['component']['props']['list']
+
+        data = next((item for item in items if item.get('player', {}).get('config', {}).get('sources')), None)
+        if not data:
+            Logger.error("No player sources found in ABC JSON")
+            return ""
+
+        # urls_all = data['player']['config']['sources']
+        # Logger.debug(f"ALL ABC video sources (unfiltered): {urls_all}")
+
+        urls = [x for x in data['player']['config']['sources'] if x.get('type') == 'video/mp4']
+        if not urls:
+            Logger.error("No MP4 sources found in ABC player config")
+            return ""
+
+        Logger.debug(f"ABC video sources available: {[{k: v for k, v in u.items() if k != 'type'} for u in urls]}")
+
+        def quality_key(source):
+            if 'fileSize' in source:
+                return source['fileSize']
+            match = re.search(r'(\d+)p', source.get('label', '0'))
+            return int(match.group(1)) if match else 0
+
+        url = sorted(urls, key=quality_key, reverse=True)[0]['file']
+
+        if not url or not url.startswith('http'):
+            Logger.error(f"ABC returned a suspicious video URL: {url}")
+            return ""
+
+        Logger.debug(f"Selected ABC video: {url} (from {len(urls)} sources)")
+        return url
 
     except Exception as inst:
         Logger.error(f"Couldn't get ABC video URL from scraped page: {inst}")

--- a/resources/lib/abc/abc_video.py
+++ b/resources/lib/abc/abc_video.py
@@ -78,10 +78,10 @@ def get_abc_weather_video_link():
             match = re.search(r'(\d+)p', source.get('label', '0'))
             return int(match.group(1)) if match else 0
 
-        url = sorted(urls, key=quality_key, reverse=True)[0]['file']
+        url = sorted(urls, key=quality_key, reverse=True)[0].get('file', '')
 
-        if not url or not url.startswith('http'):
-            Logger.error(f"ABC returned a suspicious video URL: {url}")
+        if not url or not re.match(r'^https?://[^/\s]+', url):
+            Logger.error(f"ABC returned a weird video URL?!: {url}")
             return ""
 
         Logger.debug(f"Selected ABC video: {url} (from {len(urls)} sources)")


### PR DESCRIPTION
Upstream changes broke scraping of the ABC weather video.

Fix, and attempt to make a little more robust, and increase logging in the case of misadventures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ABC weather video scraping that was broken due to upstream changes
  * Enhanced video quality selection with improved detection based on file size and resolution metadata
  * Added validation to ensure all returned video URLs are valid HTTP(S) addresses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bossanova808/weather.ozweather/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->